### PR TITLE
update the github templates to include username and repo of the project

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic_issue.md
+++ b/.github/ISSUE_TEMPLATE/epic_issue.md
@@ -15,5 +15,5 @@ This Feature will...
 
 ## List of Tasks (Complete in order)
 
-1. [ ] [Task 1: Awesome Task Title](https://github.com/username/repository-name/issues/1)
-2. [ ] [Task 2: Awesome Task Title](https://github.com/username/repository-name/issues/2)
+1. [ ] [Task 1: Awesome Task Title](https://github.com/cpalte/CloudResume/issues/1)
+2. [ ] [Task 2: Awesome Task Title](https://github.com/cpalte/CloudResume/issues/2)

--- a/.github/ISSUE_TEMPLATE/small_issue.md
+++ b/.github/ISSUE_TEMPLATE/small_issue.md
@@ -17,4 +17,4 @@ This Task will...
 
 <!-- The link below should link to its Epic Parent. -->
 
-[Feature: Awesome Feature Title](https://github.com/username/repository-name/issues/1)
+[Feature: Awesome Feature Title](https://github.com/cpalte/CloudResume/issues/1)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Story Title
 
-[This is the Issue Title](https://github.com/username/repository-name/issues/1)
+[This is the Issue Title](https://github.com/cpalte/CloudResume/issues/1)
 
 ## Changes made
 


### PR DESCRIPTION
# Story Title

[Add Github Templates](https://github.com/cpalte/CloudResume/issues/2)

## Changes made

- the username and repo name is now included in the templates

## How does the solution address the problem

This PR will update the templates

## Linked issues